### PR TITLE
compatibility with variadic parameters

### DIFF
--- a/simpn/simulator.py
+++ b/simpn/simulator.py
@@ -459,7 +459,11 @@ class SimProblem:
         if not callable(behavior):
             raise TypeError("Event " + t_name + ": the behavior must be a function. (Maybe you made it a function call, exclude the brackets.)")
         parameters = inspect.signature(behavior).parameters
-        if len(parameters) != len(inflow):
+        num_mandatory_params = sum(
+            1 for p in parameters.values()
+            if p.kind not in [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD] # count all parameters which are not "*args" or "**kwargs"
+        )
+        if num_mandatory_params > len(inflow):
             raise TypeError("Event " + t_name + ": the behavior function must take as many parameters as there are input variables.")
 
         # Check constraint
@@ -467,8 +471,12 @@ class SimProblem:
             if not callable(guard):
                 raise TypeError("Event " + t_name + ": the constraint must be a function. (Maybe you made it a function call, exclude the brackets.)")
             parameters = inspect.signature(guard).parameters
-            if len(parameters) != len(inflow):
-                raise TypeError("Event " + t_name + ": the constraint function must take as many parameters as there are input variables.")
+        num_mandatory_params = sum(
+            1 for p in parameters.values()
+            if p.kind not in [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD] # count all parameters which are not "*args" or "**kwargs"
+        )
+        if num_mandatory_params > len(inflow):
+            raise TypeError("Event " + t_name + ": the constraint function must take as many parameters as there are input variables.")
 
         # Check queue operations: if the inflow is only queue vars, but the outflow is not, we post a warning.
         inflow_queues = all([isinstance(i, SimVarQueue) for i in inflow])

--- a/simpn/simulator.py
+++ b/simpn/simulator.py
@@ -471,12 +471,12 @@ class SimProblem:
             if not callable(guard):
                 raise TypeError("Event " + t_name + ": the constraint must be a function. (Maybe you made it a function call, exclude the brackets.)")
             parameters = inspect.signature(guard).parameters
-        num_mandatory_params = sum(
-            1 for p in parameters.values()
-            if p.kind not in [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD] # count all parameters which are not "*args" or "**kwargs"
-        )
-        if num_mandatory_params > len(inflow):
-            raise TypeError("Event " + t_name + ": the constraint function must take as many parameters as there are input variables.")
+            num_mandatory_params = sum(
+                1 for p in parameters.values()
+                if p.kind not in [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD] # count all parameters which are not "*args" or "**kwargs"
+            )
+            if num_mandatory_params > len(inflow):
+                raise TypeError("Event " + t_name + ": the constraint function must take as many parameters as there are input variables.")
 
         # Check queue operations: if the inflow is only queue vars, but the outflow is not, we post a warning.
         inflow_queues = all([isinstance(i, SimVarQueue) for i in inflow])


### PR DESCRIPTION
First of all, thank you for developing the PetriNet/DES simulator. It's a great tool!

I have updated the parameter validation to support user variadic functions. It is useful when the number of input parameters is unknown at coding time or when working with a large system (e.g., a full-scale factory).

Below is an example:

```
from simpn.simulator import SimProblem, SimToken

P = SimProblem()

clock = P.add_var("clock")
places=[clock]
N=5 #<--- changing the PetriNet topology
for i in range(N):
    places.append( P.add_var("S"+str(i)) )

def behavior(clock, *stores):
    out=[SimToken(clock+1, delay=1)]
    for store in stores:
        out.append( SimToken(store+1, delay=1) )
    return out

def guard(clock, *stores):
    return sum(stores)<100

# init 0
for p in places:
    p.put(0,time=0)

P.add_event(inflow=places, outflow=places, behavior=behavior, guard=guard)

# Running
from simpn.reporters import SimpleReporter
P.simulate(10, SimpleReporter())
from simpn.visualisation import Visualisation
v = Visualisation(P)
v.show()
```
