### PR TITLE
Same code, different nodes

### DIFF
--- a/simpn/function_registry.py
+++ b/simpn/function_registry.py
@@ -1,0 +1,58 @@
+import types
+import functools
+
+
+class FunctionRegistry:
+    def __init__(self, sep: str = ":"):
+        """
+        Assigns unique names to functions to ensure different events can have the same behavior but distinct names.
+        It also perform function copy operations to have different name, but no undesirable side effect on global
+        variable and object attributes.
+        """
+        self.previous_functions = dict()
+        # Separator to distinguish between user-defined names and generated names
+        self.sep = sep
+
+    def rename_callable(self, func):
+        is_an_attribute_of_an_object = hasattr(func, "__self__") and func.__self__ is not None
+        func_name = func.__name__
+
+        is_never_seen_before = func_name not in self.previous_functions
+        if is_never_seen_before:
+            # First time seeing this function name, initialize the counter
+            self.previous_functions[func.__name__] = 1
+            return func  # No need to rename it for the first instance
+
+        if is_an_attribute_of_an_object:
+            # If it's a bound method (has __self__), handle it separately
+            instance = func.__self__
+
+            # Increment identifier for future calls
+            identifier = str(self.previous_functions[func_name])
+            self.previous_functions[func_name] += 1
+
+            # Create a new function name with a unique identifier
+            new_func_name = func_name + self.sep + identifier
+            # Wrap the method using functools.partial to retain the bound instance
+            func2 = functools.partial(func)
+            func2.__name__ = new_func_name
+
+        else:
+            # Increment identifier for future calls
+            identifier = str(self.previous_functions[func.__name__])
+            self.previous_functions[func.__name__] += 1
+
+            # Create a new function object with a new unique name
+            new_func_name = func.__name__ + self.sep + identifier
+
+            func2 = types.FunctionType(code=func.__code__,
+                                       globals=func.__globals__,
+                                       name=new_func_name,
+                                       closure=func.__closure__)
+
+            # Copy over important metadata
+            func2.__dict__.update(func.__dict__)  # Copy attributes
+            func2.__doc__ = func.__doc__  # Copy docstring
+            func2.__annotations__ = func.__annotations__  # Copy annotations
+
+        return func2

--- a/simpn/simulator.py
+++ b/simpn/simulator.py
@@ -1,7 +1,7 @@
 import inspect
 from sortedcontainers import SortedList
 import simpn.visualisation as vis
-
+from simpn.function_registry import FunctionRegistry
 
 class SimVar:
     """
@@ -287,6 +287,7 @@ class SimProblem:
         self.clock = 0
         self._debugging = debugging
         self.clock_checkpoints = dict()
+        self.function_registry=FunctionRegistry()
 
     def __str__(self):
         result = ""
@@ -430,6 +431,9 @@ class SimProblem:
         :param guard: a function that takes as many parameters as there are incoming SimVar. The function must evaluate to True or False for all possible values of SimVar. The event can only happen for values for which the guard function evaluates to True.
         :return: a SimEvent with the specified parameters.
         """
+
+        # Manage the situation where the behavior is chained
+        behavior=self.function_registry.rename_callable(behavior)
 
         # Check name
         t_name = name


### PR DESCRIPTION
This pull request resolves the issue where multiple nodes in a simulation share the same behavior function, leading to name conflicts. Currently, the code raises a `TypeError` when two nodes attempt to use the same function, as node names must be unique.

With this update, the system will automatically rename the behavior functions when necessary, ensuring unique node names while visually representing their shared origin in the graph. For example, if a function `scale` is reused, the nodes will be displayed as `scale`, `scale:1`, `scale:2` ..., indicating they stem from the same original function but represent different nodes in the Petri Net.


```
from simpn.simulator import SimProblem, SimToken

P = SimProblem()
S0 = P.add_var("S0")
S1 = P.add_var("S1")
S2 = P.add_var("S2")

def scale(x):
    y = x*2
    return [ SimToken(y, delay=1) ]
P.add_event(inflow=[S0], outflow=[S1], behavior=scale)
P.add_event(inflow=[S1], outflow=[S2], behavior=scale) # TypeError: Event scale: node with the same name already exists. Names must be unique.

# init 1
S0.put(1,time=0)

# Running
from simpn.reporters import SimpleReporter
P.simulate(4, SimpleReporter())
from simpn.visualisation import Visualisation
v = Visualisation(P)
v.show()
```

This PR also supports more complex scenarios, such as when behavior functions come from stateful objects:

```
from simpn.simulator import SimProblem, SimToken

P = SimProblem()
S0 = P.add_var("S0")
S1 = P.add_var("S1")
S2 = P.add_var("S2")

class LP: # stateful behaviour
    def __init__(self, init_delta):
        self.delta = init_delta

    def progressive_add(self, x):
        y = x + self.delta
        self.delta+=self.delta
        return [SimToken(y, delay=1)]

    def guard(self, x):
        return x < 1000

lp2 = LP(1)  # add +1, +2, +4 ...
lp3 = LP(10)  # add 10, 20, 40, ....
lp4 = LP(100)  # add 100, 200, 400, ...
P.add_event(inflow=[S0], outflow=[S1], behavior=lp2.progressive_add, guard=lp2.guard)
P.add_event(inflow=[S1], outflow=[S2], behavior=lp3.progressive_add, guard=lp3.guard)
P.add_event(inflow=[S2], outflow=[S0], behavior=lp4.progressive_add, guard=lp4.guard)

# x is 0->(+1)-> 1 -> +10 -> 11 -> +100 -> 111 -> +2 -> 113 -> +20 -> 133 -> +200 -> 333 -> +4 -> 337 -> +40 -> 377 -> + 400 -> 777 , ...

# init 0
S0.put(0, time=0) # init x to 0

# Running
from simpn.reporters import SimpleReporter

P.simulate(0.5, SimpleReporter())
from simpn.visualisation import Visualisation

v = Visualisation(P)
v.show()
```

Several unit tests have been added to verify the correctness of function renaming and behavior execution.