### PR TITLE
feat: Event binding speed up

### DIFF
--- a/simpn/prototypes_queueing.py
+++ b/simpn/prototypes_queueing.py
@@ -73,12 +73,14 @@ class QueueingGenerator(prototypes.Prototype):
 
 
 class QueueingQueue(SimVar):
-    def __init__(self, model, _id, priority=lambda token: token.time):
+    def __init__(self, model, _id, priority=None):
         """
         A SimVar that represents a queue in a queueing system.
         It is just a SimVar with a different visualisation.
+        By default FCFS selection within a queue and random selection between queues.
         """
         super().__init__(_id, priority)
+        model.set_binding_priority(model.PRIORITY_QUEUE_BINDING)
 
         model.add_prototype_var(self)
 
@@ -220,12 +222,14 @@ class QueueingServer(prototypes.Prototype):
 
 
 class QueueingSink(SimVar):
-    def __init__(self, model, _id, priority=lambda token: token.time):
+    def __init__(self, model, _id, priority=None):
         """
         A SimVar that represents a sink.
         It is just a SimVar with a different visualisation.
         """
         super().__init__(_id, priority)
+        if priority is not None:
+            model.set_binding_priority(model.PRIORITY_BINDING)
 
         model.add_prototype_var(self)
 

--- a/simpn/simulator.py
+++ b/simpn/simulator.py
@@ -350,9 +350,21 @@ class SimProblem:
     :param debugging: if set to True, produces more information for debugging purposes (defaults to True).
     :param binding_priority: a function that takes a list of binding as input and returns the binding that will be selected in case there are multiple possible bindings to fire (defaults to random selection).
     """
-    DEFAULT_PRIORITY = lambda bindings: choice(bindings)
+    RANDOM_BINDING = lambda bindings: choice(bindings)
+    def PRIORITY_BINDING(bindings):
+        """ Prioritized bindings per event, and prioritized selection between events. """
+        return bindings[0]
+    def PRIORITY_QUEUE_BINDING(bindings):
+        """ Prioritized bindings per event, but random selection between events. """
+        first_items = []
+        processed_events = set()
+        for (binding, time, event) in bindings:
+            if event not in processed_events:
+                first_items.append((binding, time, event))
+                processed_events.add(event)
+        return choice(first_items)
 
-    def __init__(self, debugging=True, binding_priority=DEFAULT_PRIORITY):
+    def __init__(self, debugging=True, binding_priority=RANDOM_BINDING):
         self.places = []
         self.events = []
         self.prototypes = []
@@ -410,7 +422,7 @@ class SimProblem:
         result += "}"                
         return result
 
-    def add_var(self, name, priority=lambda token: token.time):
+    def add_var(self, name, priority=None):
         """
         Creates a new SimVar with the specified name as identifier. Adds the SimVar to the problem and returns it.
 

--- a/simpn/simulator.py
+++ b/simpn/simulator.py
@@ -648,7 +648,7 @@ class SimProblem:
         """
         nr_incoming_places = len(event.incoming)
         if nr_incoming_places == 0:
-            raise Exception("Though it is strictly speaking possible, we do not allow events like '" + str(self) + "' without incoming arcs.")
+            raise Exception("Though it is strictly speaking possible, we do not allow events without incoming arcs.")
 
         bindings = [[]]
         # note: the marking has a totally ordered set of tokens

--- a/simpn/simulator.py
+++ b/simpn/simulator.py
@@ -1,7 +1,10 @@
 import inspect
 from sortedcontainers import SortedList
 import simpn.visualisation as vis
+
 from random import choice
+from typing import List, Tuple 
+from itertools import product
 
 class SimVar:
     """
@@ -620,7 +623,14 @@ class SimProblem:
         self.binding_priority = func
 
     @staticmethod
-    def tokens_combinations(event):
+    def tokens_combinations(event) \
+        -> List[ 
+                Tuple[
+                    List[Tuple[str,str]],
+                    float, 
+                    List
+                    ]
+            ]:
         """
         Creates a list of token combinations that are available to the specified event.
         These are combinations of tokens that are on the incoming SimVar of the event.
@@ -628,9 +638,13 @@ class SimProblem:
         the possible combinations are [(a, 1@0), (b, 2@0)] and [(a, 1@0), (b, 3@0)]
 
         :param event: the event to return the token combinations for.
-        :return: a list of lists, each of which is a token combination.
+        :return: a list of triples, where each triple describes the binding,
+        the activation time, and the variable values of the binding.
         """
-        # create all possible combinations of incoming token values
+        nr_incoming_places = len(event.incoming)
+        if nr_incoming_places == 0:
+            raise Exception("Though it is strictly speaking possible, we do not allow events like '" + str(self) + "' without incoming arcs.")
+
         bindings = [[]]
         place_token_products = [
             list(product([place], [ tok  for tok  in place.marking ]))
@@ -656,7 +670,7 @@ class SimProblem:
             if len(binding) == nr_incoming_places
         ]
         return bindings
-
+    
     def event_bindings(self, event):
         """
         Calculates the set of bindings that enables the given event.
@@ -671,68 +685,93 @@ class SimProblem:
         :param event: the event for which to calculate the enabling bindings.
         :return: list of tuples ([(place, token), (place, token), ...], time)
         """
-        if len(event.incoming) == 0:
+        nr_incoming_places = len(event.incoming)
+        if nr_incoming_places == 0:
             raise Exception("Though it is strictly speaking possible, we do not allow events like '" + str(self) + "' without incoming arcs.")
 
         bindings = self.tokens_combinations(event)
 
-        # a binding must have all incoming places
-        nr_incoming_places = len(event.incoming)
-        new_bindings = []
-        for binding in bindings:
-            if len(binding) == nr_incoming_places:
-                new_bindings.append(binding)
-        bindings = new_bindings
-
         # if a event has a guard, only bindings are enabled for which the guard evaluates to True
-        result = []
-        for binding in bindings:
-            variable_values = []
-            time = None
-            for (place, token) in binding:
-                variable_values.append(token.value)
-                if time is None or token.time > time:
-                    time = token.time
-            enabled = True
-            if event.guard is not None:
-                try:
-                    enabled = event.guard(*variable_values)
-                except Exception as e:
-                    raise TypeError("Event " + event + ": guard generates exception for values " + str(variable_values) + ".") from e
-                if self._debugging and not isinstance(enabled, bool):
-                    raise TypeError("Event " + event + ": guard does evaluate to a Boolean for values " + str(variable_values) + ".")
-            if enabled:
-                result.append((binding, time))
+        if event.guard is not None:
+            result = [
+                (binding, time)
+                for (binding, time, variable_values)
+                in bindings
+                if event.guard(*variable_values)
+            ]
+        else :
+            result = [
+                (binding, time)
+                for (binding, time, _)
+                in bindings
+            ]
         return result
 
     def bindings(self):
         """
-        Calculates the set of timed bindings that is enabled over all events in the problem.
-        Each binding is a tuple ([(place, token), (place, token), ...], time, event) that represents a single enabling binding.
-        If no timed binding is enabled at the current clock time, updates the current clock time to the earliest time at which there is.
+        Calculates the set of timed bindings that is enabled over all 
+        events in the problem. Each binding is a tuple ([(place, token), 
+        (place, token), ...], time, event) that represents a single enabling 
+        binding. If no timed binding is enabled at the current clock time, 
+        updates the current clock time to the earliest time at which there is.
+        
         :return: list of tuples ([(place, token), (place, token), ...], time, event)
         """
-        timed_bindings = []
         min_enabling_time = None
-        for t in self.events:
-            for (binding, time) in self.event_bindings(t):
-                timed_bindings.append((binding, time, t))
-                if min_enabling_time is None or time < min_enabling_time:
-                    min_enabling_time = time
+
+        # find the earliest enabling time for an event's incoming markings
+        timings = dict()
+        for ev in self.events:
+            smallest = []
+            skip = False
+            added = False
+            
+            # identify when the earlier token could be used from places 
+            # of the event
+            for place in ev.incoming:
+                try:
+                    smallest.append(place.marking[0].time)
+                    added = True
+                except:
+                    skip = True
+            
+            if (skip or not added):
+                timings[ev] = 0
+                continue
+            
+            # only keep the latest of the set of early tokens across places
+            smallest_largest = max(smallest)
+            timings[ev] = smallest_largest
+
+            if (smallest_largest == 0):
+                continue
+
+            # keep track of the smallest next possible clock
+            if (smallest_largest is not None) \
+                and (min_enabling_time is None \
+                        or smallest_largest < min_enabling_time):
+                min_enabling_time = smallest_largest 
+
         # timed bindings are only enabled if they have time <= clock
-        # if there are no such bindings, set the clock to the earliest time at which there are
+        # if there are no such bindings, set the clock to the earliest time 
+        # at which there are
         if min_enabling_time is not None and min_enabling_time > self.clock:
             self.clock = min_enabling_time
-            # We now also need to update the bindings, because the SimVarTime may have changed and needs to be updated.
-            # TODO This is inefficient, because we are recalculating all bindings, while we only need to recalculate the ones that have SimVarTime in their inflow.
-            timed_bindings = [] 
-            for t in self.events:
-                for (binding, time) in self.event_bindings(t):
+        # We generate bindings and only do so if an event would produce a 
+        # binding before the current clock
+        timed_bindings = [] 
+        for t, earlist in timings.items():
+            # skip events with no chance of producing bindings before the 
+            # clock
+            if earlist > self.clock:
+                continue
+            # now return the untimed bindings + the timed bindings that have 
+            # time <= clock
+            for (binding, time) in self.event_bindings(t):
+                if (time <= self.clock):
                     timed_bindings.append((binding, time, t))
-
-        # now return the untimed bindings + the timed bindings that have time <= clock
-        return [(binding, time, t) for (binding, time, t) in timed_bindings if time <= self.clock]
-
+        return timed_bindings
+    
     def fire(self, timed_binding):
         """
         Fires the specified timed binding.

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -177,6 +177,10 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(test_problem.bindings(), [([(a, SimToken("a1", 0)), (b, SimToken("a1", 0))], 0, ta),  ([(a, SimToken("a2", 0)), (b, SimToken("a2", 0))], 0, ta)], "correct token combinations")
 
     def test_bindings_timing(self):
+        # starting at time 0, with four possible token combinations a1, b1; a1, b2; a2, b1; a2, b2
+        # no token combination is possible at time 0, because neither a1 nor a2 is available at time 0
+        # the earliest possible time is 1, this should then become the enabling time of the transition
+        # at time 1, only a2 is available, so only the combinations a2, b1 and a2, b2 are possible
         test_problem = SimProblem()
         a = test_problem.add_var("a")
         a.put("a1", 2)
@@ -187,6 +191,27 @@ class TestBasics(unittest.TestCase):
         ta = test_problem.add_event([a, b], [], lambda c, d: [], name="ta")
         self.assertEqual(test_problem.bindings(), [([(a, SimToken("a2", 1)), (b, SimToken("b1", 0))], 1, ta),  ([(a, SimToken("a2", 1)), (b, SimToken("b2", 1))], 1, ta)], "correct token combinations")
 
+    def test_bindings_timing_complex(self):
+        # just for completeness, a more complex example with 3 places
+        # earliest time is 5 because of c1, at this time there are four possible combinations: a1, b1, c1; a1, b2, c1; a2, b1, c1; a2, b2, c1
+        test_problem = SimProblem()
+        a = test_problem.add_var("a")
+        a.put("a1", 1)
+        a.put("a2", 2)
+        b = test_problem.add_var("b")
+        b.put("b2", 4)
+        b.put("b1", 3)
+        c = test_problem.add_var("c")
+        c.put("c1", 5)
+        c.put("c2", 6)
+        ta = test_problem.add_event([a, b, c], [], lambda d, e, f: [], name="ta")
+        self.compare_two_binding_sets(
+            [([(a, SimToken("a1", 1)), (b, SimToken("b1", 3)), (c, SimToken("c1", 5))], 5, ta), 
+             ([(a, SimToken("a1", 1)), (b, SimToken("b2", 4)), (c, SimToken("c1", 5))], 5, ta), 
+             ([(a, SimToken("a2", 2)), (b, SimToken("b1", 3)), (c, SimToken("c1", 5))], 5, ta),
+             ([(a, SimToken("a2", 2)), (b, SimToken("b2", 4)), (c, SimToken("c1", 5))], 5, ta)]
+            , test_problem.bindings())
+        
     def test_fire_result(self):
         test_problem = SimProblem()
         a = test_problem.add_var("a")
@@ -422,9 +447,91 @@ class TestTimeVariable(unittest.TestCase):
 
         self.assertEqual(time_var.marking, [SimToken(2)], "There is one token with value 2")
 
+
 class TestPriorities(unittest.TestCase):
 
-    def test_time_driven_prio(self):
+    def test_basic_time_driven_prio(self):
+        # this is a version of the test_bindings_timing test, but just double checking that the priority function returns the correct binding.
+        # we have one place a with time-driven priority (lowest time first) with tokens with times 1, 2, 3, ... (in the place in random order)
+        # and one place b without priority (random) with times 3, 6, 9 (in the place in random order)
+        # current time is 0, so earliest possible time is 3
+        test_problem = SimProblem()
+        a = test_problem.add_var("a")
+        a.put("a7", 7); a.put("a2", 2); a.put("a9", 9); a.put("a4", 4); a.put("a1", 1); a.put("a6", 6); a.put("a3", 3); a.put("a8", 8); a.put("a5", 5)
+        b = test_problem.add_var("b", priority=lambda token: 1/token.time) # we invert the time priority to double-check that still 3 goes first
+        b.put("b9", 9)
+        b.put("b6", 6)
+        b.put("b3", 3)
+        ta = test_problem.add_event([a, b], [], lambda c, d: [], name="ta")
+        # on a single queue, the tokens are always in time order
+        self.assertEqual(test_problem.bindings(), 
+                         [([(a, SimToken("a1", 1)), (b, SimToken("b3", 3))], 3, ta), 
+                          ([(a, SimToken("a2", 2)), (b, SimToken("b3", 3))], 3, ta),
+                          ([(a, SimToken("a3", 3)), (b, SimToken("b3", 3))], 3, ta),
+                          ],
+                         "correct token combinations")
+
+    def test_basic_time_driven_prio_multiple_transitions(self):
+        # if there are two queues, by default tokens within a single queue are always in time order
+        test_problem = SimProblem()
+        a = test_problem.add_var("a")
+        a.put("a7", 7); a.put("a2", 2); a.put("a9", 9); a.put("a4", 4); a.put("a1", 1); a.put("a6", 6); a.put("a3", 3); a.put("a8", 8); a.put("a5", 5)
+        b = test_problem.add_var("b", priority=lambda token: 1/token.time) # we invert the time priority to double-check that still 3 goes first
+        b.put("b9", 9); b.put("b6", 6); b.put("b3", 3)
+        ta = test_problem.add_event([a, b], [], lambda c, d: [], name="ta")
+        c = test_problem.add_var("c")
+        c.put("c7", 7); c.put("c2", 2); c.put("c9", 9); c.put("c4", 4); c.put("c1", 1); c.put("c6", 6); c.put("c3", 3); c.put("c8", 8); c.put("c5", 5)
+        d = test_problem.add_var("d", priority=lambda token: 1/token.time) # we invert the time priority to double-check that still 3 goes first
+        d.put("d9", 9); d.put("d6", 6); d.put("d3", 3)
+        tb = test_problem.add_event([c, d], [], lambda e, f: [], name="tb")
+
+        # on a single queue, the tokens are always in time order
+        self.assertEqual([(binding_vals, binding_time, binding_event) for (binding_vals, binding_time, binding_event) in test_problem.bindings() if binding_event == ta], 
+                         [([(a, SimToken("a1", 1)), (b, SimToken("b3", 3))], 3, ta), 
+                          ([(a, SimToken("a2", 2)), (b, SimToken("b3", 3))], 3, ta),
+                          ([(a, SimToken("a3", 3)), (b, SimToken("b3", 3))], 3, ta),
+                          ],
+                         "correct token combinations on ta")
+        self.assertEqual([(binding_vals, binding_time, binding_event) for (binding_vals, binding_time, binding_event) in test_problem.bindings() if binding_event == tb], 
+                         [([(c, SimToken("c1", 1)), (d, SimToken("d3", 3))], 3, tb), 
+                          ([(c, SimToken("c2", 2)), (d, SimToken("d3", 3))], 3, tb),
+                          ([(c, SimToken("c3", 3)), (d, SimToken("d3", 3))], 3, tb),
+                          ],
+                         "correct token combinations on tb")
+
+    def test_basic_time_driven_prio_random_transition(self):
+        test_problem = SimProblem(binding_priority=SimProblem.PRIORITY_QUEUE_BINDING)
+        a = test_problem.add_var("a")
+        a.put("a7", 7); a.put("a2", 2); a.put("a9", 9); a.put("a4", 4); a.put("a1", 1); a.put("a6", 6); a.put("a3", 3); a.put("a8", 8); a.put("a5", 5)
+        b = test_problem.add_var("b", priority=lambda token: 1/token.time) # we invert the time priority to double-check that still 3 goes first
+        b.put("b9", 9); b.put("b6", 6); b.put("b3", 3)
+        ta = test_problem.add_event([a, b], [], lambda c, d: [], name="ta")
+        c = test_problem.add_var("c")
+        c.put("c7", 7); c.put("c2", 2); c.put("c9", 9); c.put("c4", 4); c.put("c1", 1); c.put("c6", 6); c.put("c3", 3); c.put("c8", 8); c.put("c5", 5)
+        d = test_problem.add_var("d", priority=lambda token: 1/token.time) # we invert the time priority to double-check that still 3 goes first
+        d.put("d9", 9); d.put("d6", 6); d.put("d3", 3)
+        tb = test_problem.add_event([c, d], [], lambda e, f: [], name="tb")
+
+        # we do this 20 times to account for randomness
+        count_ta = 0
+        count_tb = 0
+        for _ in range(20):
+            binding = test_problem.binding_priority(test_problem.bindings())
+            if binding[2] == ta:
+                count_ta += 1
+                # the binding must be fired for the first item in the queue, which is a1
+                self.assertEqual(binding[0], [(a, SimToken("a1", 1)), (b, SimToken("b3", 3))], "the binding must be fired for the first item in the queue, which is a1")
+            elif binding[2] == tb:
+                count_tb += 1
+                # the binding must be fired for the first item in the queue, which is c1
+                self.assertEqual(binding[0], [(c, SimToken("c1", 1)), (d, SimToken("d3", 3))], "the binding must be fired for the first item in the queue, which is c1")
+            else:
+                self.fail("binding must be for either ta or tb")
+        # because of randomness, each of the two transitions should be chosen at least once
+        self.assertGreater(count_ta, 0, "ta must be chosen at least once, it is possible - though unlikely - that this test fails due to randomness")
+        self.assertGreater(count_tb, 0, "tb must be chosen at least once, it is possible - though unlikely - that this test fails due to randomness")
+
+    def test_bpmn_time_driven_prio(self):
         test_problem = SimProblem()
 
         task1_queue = test_problem.add_var("task1_queue")
@@ -445,7 +552,7 @@ class TestPriorities(unittest.TestCase):
         completion_count = 0
         while test_problem.clock <= 20:
             bindings = test_problem.bindings()
-            (binding, time, event) = bindings[0]
+            (binding, time, event) = test_problem.binding_priority(bindings)
             test_problem.fire((binding, time, event))
 
             # we check if the tokens in the queues always have time <= the global clock
@@ -466,7 +573,7 @@ class TestPriorities(unittest.TestCase):
             
         self.assertGreater(completion_count, 10, "there are at least 10 completions")
 
-    def test_priority_driven_prio(self):
+    def test_bpmn_priority_driven_prio(self):
         test_problem = SimProblem()
 
         def priority(token):
@@ -490,7 +597,7 @@ class TestPriorities(unittest.TestCase):
         start2_count = 0
         while test_problem.clock <= 50:
             bindings = test_problem.bindings()
-            (binding, time, event) = bindings[0]
+            (binding, time, event) = test_problem.binding_priority(bindings)
             test_problem.fire((binding, time, event))
 
             # tokens with higher priority must always start first

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -448,7 +448,7 @@ class TestPriorities(unittest.TestCase):
         completion_count = 0
         while test_problem.clock <= 20:
             bindings = test_problem.bindings()
-            (binding, time, event) = test_problem.binding_priority(bindings)
+            (binding, time, event) = bindings[0]
             test_problem.fire((binding, time, event))
 
             # we check if the tokens in the queues always have time <= the global clock
@@ -463,10 +463,8 @@ class TestPriorities(unittest.TestCase):
             if event._id == "task2<task:complete>":
                 completion_count += 1
                 completion = int(binding[0][1].value[0][0])
-                # so is the expectation of the bindings return that it 
-                # is sorted by FIFO?
-                # if last_completion is not None:
-                #     self.assertGreaterEqual(completion, last_completion, "jobs are completed in the order of their arrival")
+                if last_completion is not None:
+                    self.assertGreaterEqual(completion, last_completion, "jobs are completed in the order of their arrival")
                 last_completion = completion
             
         self.assertGreater(completion_count, 10, "there are at least 10 completions")
@@ -495,7 +493,7 @@ class TestPriorities(unittest.TestCase):
         start2_count = 0
         while test_problem.clock <= 50:
             bindings = test_problem.bindings()
-            (binding, time, event) = test_problem.binding_priority(bindings)
+            (binding, time, event) = bindings[0]
             test_problem.fire((binding, time, event))
 
             # tokens with higher priority must always start first

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -495,7 +495,7 @@ class TestPriorities(unittest.TestCase):
         start2_count = 0
         while test_problem.clock <= 50:
             bindings = test_problem.bindings()
-            (binding, time, event) = bindings[0]
+            (binding, time, event) = test_problem.binding_priority(bindings)
             test_problem.fire((binding, time, event))
 
             # tokens with higher priority must always start first

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -422,13 +422,10 @@ class TestTimeVariable(unittest.TestCase):
 
         self.assertEqual(time_var.marking, [SimToken(2)], "There is one token with value 2")
 
-from random import choice
 class TestPriorities(unittest.TestCase):
 
     def test_time_driven_prio(self):
-        test_problem = SimProblem(
-            binding_priority= lambda x: choice(x)
-        )
+        test_problem = SimProblem()
 
         task1_queue = test_problem.add_var("task1_queue")
         task2_queue = test_problem.add_var("task2_queue")


### PR DESCRIPTION
This PR revisits the problematic parts of the previous event binding optimisations. All tests have been updated for the changed combination binding function with reduces the number of times we need to iterate over the possibly large set of places in unstable simulations. Locally the tests pass, but let's see if they pass on remote.

remade to see if the tests will run on PR now.