### PR TITLE
feat: add dev workflow to push to testpypi

### DIFF
--- a/.github/workflows/python-test-publish.yml
+++ b/.github/workflows/python-test-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Get version components
         id: get-components
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          SHORT_SHA=${GITHUB_RUN_NUMBER}
           PVERSION=$(grep -Po "(?<=version = \")(.*)(?=\")" pyproject.toml)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           echo "PVERSION=$PVERSION" >> $GITHUB_ENV
@@ -63,7 +63,7 @@ jobs:
       - name: Create new version and modify files
         id: version
         run: |
-          NVZERSION="${PVERSION}+dev.${SHORT_SHA}"
+          NVZERSION="${PVERSION}.dev${SHORT_SHA}"
           echo "NVZERSION=$NVZERSION" >> $GITHUB_ENV
           echo "using version :: $NVZERSION"
           echo "version=$NVZERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This makes it so that pushes to dev are tested, built and made into a packaged version on testpypi. Which is useful for sharing early versions with others and users to test them out. It was a bit of pain to make the workflow action work but I got there in the end. 

The creditionals for uploading the package are stored as a github secret, but the github action does reccommend considering Trusted Publisher CI on pypi instead of storing api-tokens, see below or https://docs.pypi.org/trusted-publishers/ for more info:

> A new Trusted Publisher for the currently running publishing workflow can be created by accessing the following link(s) while logged-in as an owner of the package(s):
> 
> https://test.pypi.org/manage/project/simpn/settings/publishing/?provider=github&owner=bpogroup&repository=simpn&workflow_filename=python-test-publish.yml

Personally, both are secure auths but it seems like the trusted publisher route might be a bit overkill. Not a security expert.

Making the release version for main will be easier as it will be less playing around the version number on the fly to make the upload work. But after the action completes you get all the needed information to find the version on testpypi, which is helpful.

See https://github.com/bpogroup/simpn/actions/runs/18273865659.