### PR TITLE
bugfix: icons not showing in installed from pypi

### DIFF
--- a/simpn/visualisation/base.py
+++ b/simpn/visualisation/base.py
@@ -76,6 +76,7 @@ from simpn.visualisation.events import (
     Event,
 )
 from simpn.visualisation.constants import GREEN
+from simpn.assets import get_img_asset
 
 from typing import List, Tuple, TYPE_CHECKING, Literal, Union
 
@@ -272,14 +273,14 @@ class SimulationPanel(QWidget):
         # Add Step button to toolbar
         self.step_action = toolbar.addAction("Step")
         self.step_action.setToolTip("Execute one simulation step")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "ide_step.png"))
+        icon_path = resource_path(get_img_asset("ide_step.png"))
         self.step_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.step_action.triggered.connect(self.step_simulation)
         self.step_action.setEnabled(False)
 
         # Add Play button to toolbar
         self.play_action = toolbar.addAction("Play")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "ide_play.png"))
+        icon_path = resource_path(get_img_asset("ide_play.png"))
         self.play_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.play_action.setToolTip("Start continuous simulation")
         self.play_action.triggered.connect(self.start_simulation)
@@ -287,7 +288,7 @@ class SimulationPanel(QWidget):
 
         # Add Stop button to toolbar
         self.stop_action = toolbar.addAction("Stop")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "ide_stop.png"))
+        icon_path = resource_path(get_img_asset("ide_stop.png"))
         self.stop_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.stop_action.setToolTip("Stop continuous simulation")
         self.stop_action.triggered.connect(self.stop_simulation)
@@ -295,7 +296,7 @@ class SimulationPanel(QWidget):
 
         # Add reset to start to toolbar
         self.reset_action = toolbar.addAction("Reset to Start")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "time_back.png"))
+        icon_path = resource_path(get_img_asset("time_back.png"))
         self.reset_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.reset_action.setToolTip("Reset simulation to start")
         self.reset_action.triggered.connect(self.reset_simulation)
@@ -303,7 +304,7 @@ class SimulationPanel(QWidget):
 
         # Add Faster button to toolbar
         self.faster_action = toolbar.addAction("Faster")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "ide_faster.png"))
+        icon_path = resource_path(get_img_asset("ide_faster.png"))
         self.faster_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.faster_action.setToolTip("Increase simulation speed")
         self.faster_action.triggered.connect(self.faster_simulation)
@@ -311,7 +312,7 @@ class SimulationPanel(QWidget):
 
         # Add Slower button to toolbar
         self.slower_action = toolbar.addAction("Slower")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "ide_slower.png"))
+        icon_path = resource_path(get_img_asset("ide_slower.png"))
         self.slower_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.slower_action.setToolTip("Decrease simulation speed")
         self.slower_action.triggered.connect(self.slower_simulation)
@@ -322,7 +323,7 @@ class SimulationPanel(QWidget):
 
         # Add Zoom In button to toolbar
         self.zoom_in_action = toolbar.addAction("Zoom In")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "zoom-in.png"))
+        icon_path = resource_path(get_img_asset("zoom-in.png"))
         self.zoom_in_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.zoom_in_action.setToolTip("Zoom in (Ctrl++)")
         self.zoom_in_action.setShortcut("Ctrl++")
@@ -332,7 +333,7 @@ class SimulationPanel(QWidget):
 
         # Add Zoom Out button to toolbar
         self.zoom_out_action = toolbar.addAction("Zoom Out")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "zoom-out.png"))
+        icon_path = resource_path(get_img_asset("zoom-out.png"))
         self.zoom_out_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.zoom_out_action.setToolTip("Zoom out (Ctrl+-)")
         self.zoom_out_action.setShortcut("Ctrl+-")
@@ -342,7 +343,7 @@ class SimulationPanel(QWidget):
 
         # Add Zoom Reset button to toolbar
         self.zoom_reset_action = toolbar.addAction("Zoom 100%")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "zoom-reset.png"))
+        icon_path = resource_path(get_img_asset("zoom-reset.png"))
         self.zoom_reset_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.zoom_reset_action.setToolTip("Reset zoom to 100% (Ctrl+0)")
         self.zoom_reset_action.setShortcut("Ctrl+0")
@@ -355,7 +356,7 @@ class SimulationPanel(QWidget):
 
         # Add clock precision increase button to toolbar
         self.clock_increase_action = toolbar.addAction("Clock precision +")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "plus.png"))
+        icon_path = resource_path(get_img_asset("plus.png"))
         self.clock_increase_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.clock_increase_action.setToolTip("Increase clock precision")
         self.clock_increase_action.triggered.connect(self.increase_clock_precision)
@@ -363,7 +364,7 @@ class SimulationPanel(QWidget):
 
         # Add clock precision decrease button to toolbar
         self.clock_decrease_action = toolbar.addAction("Clock precision -")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "minus.png"))
+        icon_path = resource_path(get_img_asset("minus.png"))
         self.clock_decrease_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.clock_decrease_action.setToolTip("Decrease clock precision")
         self.clock_decrease_action.triggered.connect(self.decrease_clock_precision)
@@ -780,7 +781,7 @@ class ExplorerPanel(QWidget):
 
         # Run button to run replications
         self.run_action = toolbar.addAction("Run")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "ide_play.png"))
+        icon_path = resource_path(get_img_asset("ide_play.png"))
         self.run_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.run_action.setEnabled(False)  # Initially disabled, enabled when a simulator is loaded
         self.run_action.setToolTip("Run replications")
@@ -788,7 +789,7 @@ class ExplorerPanel(QWidget):
 
         # Close button with icon
         self.close_action = toolbar.addAction("Close")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "close.png"))
+        icon_path = resource_path(get_img_asset("close.png"))
         self.close_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.close_action.setToolTip("Close attribute panel")
         # Note: close action will be connected by parent to hide the dock
@@ -1050,14 +1051,14 @@ class DebugPanel(QWidget):
 
         # Clear button with icon
         clear_action = toolbar.addAction("Clear")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "clear.png"))
+        icon_path = resource_path(get_img_asset("clear.png"))
         clear_action.setIcon(create_monochrome_icon_from_file(icon_path))
         clear_action.setToolTip("Clear debug console")
         clear_action.triggered.connect(self.clear_text)
 
         # Close button with icon
         self.close_action = toolbar.addAction("Close")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "close.png"))
+        icon_path = resource_path(get_img_asset("close.png"))
         self.close_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.close_action.setToolTip("Close debug console")
         # Note: close action will be connected by parent to hide the dock
@@ -1183,7 +1184,7 @@ class AttributePanel(QWidget):
 
         # Close button with icon
         self.close_action = toolbar.addAction("Close")
-        icon_path = resource_path(os.path.join("simpn", "assets", "img", "close.png"))
+        icon_path = resource_path(get_img_asset("close.png"))
         self.close_action.setIcon(create_monochrome_icon_from_file(icon_path))
         self.close_action.setToolTip("Close attribute panel")
         # Note: close action will be connected by parent to hide the dock
@@ -1337,7 +1338,7 @@ class AboutDialog(QDialog):
 
         # Logo
         logo_label = QLabel()
-        logo_path = resource_path("simpn/assets/img/logo.png")
+        logo_path = resource_path(get_img_asset("logo.png"))
         if os.path.exists(logo_path):
             pixmap = QPixmap(logo_path)
             # Scale logo to reasonable size while maintaining aspect ratio
@@ -1407,7 +1408,7 @@ class MainWindow(QMainWindow):
         self.setGeometry(100, 100, 800, 600)
 
         # Set window icon
-        logo_path = resource_path(os.path.join("simpn", "assets", "img", "logo.png"))
+        logo_path = resource_path(get_img_asset("logo.png"))
         if os.path.exists(logo_path):
             self.setWindowIcon(QIcon(logo_path))
 
@@ -1847,7 +1848,7 @@ class Visualisation:
         self.app.setOrganizationDomain("tue.nl")
 
         # Set application icon for taskbar/dock
-        logo_path = resource_path(os.path.join("simpn", "assets", "img", "logo.png"))
+        logo_path = resource_path(get_img_asset("logo.png"))
         if os.path.exists(logo_path):
             self.app.setWindowIcon(QIcon(logo_path))
 


### PR DESCRIPTION
Bugfix for #47.

Swaps the hard coded `os.path.join` calls with `get_img_asset` calls.