### PR TITLE
feat: added a graphing panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 /temp/
 .DS_Store
+**/temp
 
 # dotenv
 .env

--- a/examples/presentation/presentation_4b.py
+++ b/examples/presentation/presentation_4b.py
@@ -1,64 +1,141 @@
-import matplotlib.pyplot as plt 
+from typing import List
+from os.path import join
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+from pygame.event import Event
+
 from simpn.simulator import SimProblem, SimToken
 from random import expovariate as exp
-from simpn.reporters import WarmupReporter, ProcessReporter
+from simpn.reporters import WarmupReporter
+from simpn.visualisation.events import EventType
+from simpn.visualisation.model_panel_mods import GraphingPanel, RecorderModule
+from simpn.visualisation.events import check_event
+from simpn.visualisation import Visualisation
 from simpn.helpers import BPMN
+
+RECORD = False
+
+
+class WarmUpGraphPanel(GraphingPanel):
+    """
+    Adds a grapher for the given reporter.
+    """
+
+    def __init__(self, reporter: WarmupReporter) -> None:
+        super().__init__(
+            25,
+            25,
+            300,
+            150,
+            "Warm up Arrival Times",
+            "The average cycle times over time.",
+        )
+        self._reporter = reporter
+
+    def listen_to(self) -> List[EventType]:
+        return super().listen_to() + [EventType.BINDING_FIRED]
+
+    def handle_event(self, event: Event) -> bool:
+        super().handle_event(event)
+        if check_event(event, EventType.BINDING_FIRED):
+            reporter.callback(event.fired)
+        return True
+
+    def create_figure(self, figure: Figure) -> Figure | None:
+        figure.patch.set_alpha(0.0)
+        axes = figure.add_subplot(111)
+        axes.patch.set_alpha(0.0)
+        axes.tick_params(axis="both", labelsize=8)
+
+        axes.plot(reporter.times, reporter.average_cycle_times, color="blue")
+        axes.set_xlabel("arrival time (min)", fontsize=8)
+        axes.set_ylabel("cycle time (min)", fontsize=8)
+
+        figure.subplots_adjust(left=0.17, right=0.90, bottom=0.25, top=0.9)
+
+        return figure
+
 
 # Instantiate a simulation problem.
 shop = SimProblem()
 
+
 # Define queues and other 'places' in the process.
 class Done(BPMN):
-    type="flow"
-    model=shop
-    name="done"
+    type = "flow"
+    model = shop
+    name = "done"
+
 
 class Waiting(BPMN):
-    type="flow"
-    model=shop
-    name="waiting"
+    type = "flow"
+    model = shop
+    name = "waiting"
+
 
 # Define helper classes for simulation
 class Cassiers(BPMN):
-    type="resource-pool"
-    model = shop 
+    type = "resource-pool"
+    model = shop
     name = "cassier"
     amount = 1
 
+
 class Start(BPMN):
-    type="start"
-    model=shop
-    name="arrive"
-    amount=1
-    outgoing=["waiting"]
+    type = "start"
+    model = shop
+    name = "arrive"
+    amount = 1
+    outgoing = ["waiting"]
 
     def interarrival_time():
-        return exp(1/10)
-    
+        return exp(1 / 10)
+
+
 class Scan(BPMN):
-    type="task"
-    model=shop
-    name="scan_groceries"
-    incoming=["waiting", "cassier"]
-    outgoing=["done", "cassier"]
+    type = "task"
+    model = shop
+    name = "scan_groceries"
+    incoming = ["waiting", "cassier"]
+    outgoing = ["done", "cassier"]
 
     def behaviour(c, r):
-        return [SimToken((c, r), delay=exp(1/9))]
-    
+        return [SimToken((c, r), delay=exp(1 / 9))]
+
+
 class End(BPMN):
-    type="end"
-    model=shop
-    name="complete"
-    incoming=["done"]
+    type = "end"
+    model = shop
+    name = "complete"
+    incoming = ["done"]
+
 
 shop.store_checkpoint("initial state")
 
 # Simulate once with a warmup reporter.
 reporter = WarmupReporter()
+graph_panel = WarmUpGraphPanel(reporter)
+mods = [
+    graph_panel
+]
+
+if RECORD:
+    recorder = RecorderModule(join(".", "temp", "presentation_4b.gif"), include_ui=True)
+    mods.append(recorder)
+
+vis = Visualisation(shop, extra_modules=mods)
+for _ in range(15):
+    vis.main_window.simulation_panel.faster_simulation()
+vis.main_window.simulation_panel.start_simulation()
+vis.show()
+
 shop.simulate(20000, reporter)
 
 plt.plot(reporter.times, reporter.average_cycle_times, color="blue")
-plt.xlabel("arrival time (min)")
+plt.xlabel("arrival time (min)", fontsize=8)
 plt.xticks(range(0, 20001, 5000))
-plt.ylabel("cycle time (min)")
+plt.yticks(fontsize=8)
+plt.xticks(range(0, 20001, 5000), fontsize=8)
+plt.ylabel("cycle time (min)", fontsize=8)
 plt.show()

--- a/sandbox/priorities_for_bps.py
+++ b/sandbox/priorities_for_bps.py
@@ -29,10 +29,17 @@ are selected first. The latter two priority classes do not support this
 functionality.
 """
 
+from typing import List
+
+from matplotlib.figure import Figure
+from pygame.event import Event
+
 from simpn.helpers import BPMN
 from simpn.prototypes import BPMNFlow
 from simpn.simulator import SimProblem, SimToken, SimTokenValue
 from simpn.visualisation import Visualisation
+from simpn.visualisation.events import EventType, check_event
+from simpn.visualisation.model_panel_mods import GraphingPanel
 
 from simpn.priorities import FirstClassPriority
 from simpn.priorities import WeightedFirstClassPriority
@@ -44,8 +51,8 @@ from os.path import join, exists
 from enum import Enum, auto
 
 LAYOUT_FILE = join(".", "temp", "priorities_for_bps.layout")
-PRIORITY = 2
-RECORD = True
+PRIORITY = 3
+RECORD = False
 
 
 class CustomerType(Enum):
@@ -81,6 +88,60 @@ class CustomerType(Enum):
 
     def __repr__(self):
         return self.__str__()
+
+
+class ActionedCustomersGraphPanel(GraphingPanel):
+    """
+    Plots a bar graph to show how many times customer type is actioned.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            width=300, height=150, 
+            title="Actioned Customer Types", 
+            subtext="Shows the number of times a customer type was actioned."
+        )
+
+        self.customers = {
+            CustomerType.NEW : 0,
+            CustomerType.BRONZE : 0,
+            CustomerType.SILVER : 0,
+            CustomerType.GOLD : 0
+        }
+
+    def listen_to(self) -> List[EventType]:
+        return super().listen_to() + [
+            EventType.BINDING_FIRED
+        ]
+    
+    def handle_event(self, event: Event) -> bool:
+        super().handle_event(event)
+
+        if check_event(event, EventType.BINDING_FIRED):
+            # update the customer tracker
+            binding = event.fired 
+            tokens:List[SimToken] = binding[0]
+            for ev, tok in tokens:
+                if hasattr(tok.value, "type"):
+                    cus_type = getattr(tok.value, "type")
+                    self.customers[cus_type] += 1
+
+    def create_figure(self, figure: Figure) -> Figure | None:
+        figure.patch.set_alpha(0.0)
+        axes = figure.add_subplot(111)
+        axes.patch.set_alpha(0.0)
+        axes.tick_params(axis="both", labelsize=8)
+
+        axes.bar(
+            [ cus.value for cus in self.customers.keys()], self.customers.values(),
+        )
+        axes.set_xticks([ cus.value for cus in self.customers.keys()])
+        axes.set_xticklabels([ str(cus) for cus in self.customers.keys()])
+        axes.set_xlabel("Customer Types", fontsize=8)
+        axes.set_ylabel("Actioned", fontsize=8)
+
+        figure.subplots_adjust(left=0.17, right=0.90, bottom=0.25, top=0.9)
+        return figure
 
 
 def employee_speed(base_time, employee: SimTokenValue):
@@ -297,6 +358,8 @@ class HandledCustomer(BPMN):
 
 
 mods = []
+graph_panel = ActionedCustomersGraphPanel()
+mods.append(graph_panel)
 if RECORD:
     from simpn.visualisation.model_panel_mods import RecorderModule
     mods.append(
@@ -307,7 +370,9 @@ if exists(LAYOUT_FILE):
     vis = Visualisation(model, layout_file=LAYOUT_FILE, extra_modules=mods)
 else:
     vis = Visualisation(model, extra_modules=mods)
-
 model.set_binding_priority(class_priority)
+for _ in range(15):
+    vis.main_window.simulation_panel.faster_simulation()
+vis.main_window.simulation_panel.start_simulation()
 vis.show()
 vis.save_layout(join(".", "temp", "priorities_for_bps.layout"))

--- a/simpn/visualisation/model_panel_mods.py
+++ b/simpn/visualisation/model_panel_mods.py
@@ -30,9 +30,14 @@ from simpn.visualisation.events import (
 )
 from dataclasses import dataclass
 from collections import deque
-from typing import List, Tuple, Literal
+from typing import List, Tuple, Literal, Optional
 from .text import prevent_overflow_while_rendering
 import imageio
+
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from math import sin
+from collections import deque
 
 
 class ClockModule(IEventHandler):
@@ -667,9 +672,7 @@ class RecorderModule(IEventHandler):
         if self._size is None:
             self._size = screen.get_width(), screen.get_height()
         temp_surface = pygame.Surface(self._size)
-        pygame.transform.smoothscale(
-            screen, self._size, temp_surface
-        )
+        pygame.transform.smoothscale(screen, self._size, temp_surface)
         frame = pygame.surfarray.array3d(temp_surface)
         frame = frame.transpose([1, 0, 2])  # Convert to (height, width, channels)
 
@@ -695,3 +698,178 @@ class RecorderModule(IEventHandler):
                 )
         else:
             raise ValueError(f"Unknown format for saving :: {self._format}")
+
+
+class GraphingPanel(IEventHandler):
+    """
+    Adds a graphing panel to the simulation panel. Users can subclass this panel
+    and override `create_figure` function to have a continously updating graph
+    visualisation while the simulation unfolds.
+
+    The position of the panel and size of the panel can be controlled by
+    the arguments to the panel.
+
+    By default the panel will show a sine wave that is connected to the
+    time of the simulation for demonstrative purposes.
+
+    :param `right_offset:int=25`:
+        An offset from the right of the screen to place the panel
+    :param `top_offset:int=25`:
+        An offset from the top of the screen to place the panel
+    :param `width:int=300`:
+        the width of the panel.
+    :param `height:int=500`:
+        the height of the panel.
+    :param `title:str='...'`:
+        text for the title of the panel.
+    :param `subtext:str='...'`:
+        text below the title of the panel.
+    :param `title_fontsize:int=14`:
+        the size of the font for the title.
+    :param `fontsize:int=12`:
+        the size of the font for all other text:
+    """
+
+    def __init__(
+        self,
+        right_offset: int = 25,
+        top_offset: int = 25,
+        width: int = 300,
+        height: int = 500,
+        title: str = "Graph Panel",
+        subtext: str = "You can add extra information via the subtext parameter",
+        title_fontsize: int = 14,
+        fontsize: int = 12,
+    ) -> None:
+        super().__init__()
+        self._title_fontsize = title_fontsize
+        self._fontsize = fontsize
+        self._history_signature = None
+        self.right_offset = right_offset
+        self.top_offset = top_offset
+        self.graph_width = width
+        self.graph_height = height
+        self.title = title
+        self.subtext = subtext
+        self.width = self.graph_width + 10
+        self.height = self.graph_height + 50
+
+        self._history_surface: Optional[Surface] = None
+        self._text_fonter: pygame.font.Font = None  # type: ignore
+        self._title_fonter: pygame.font.Font = None  # type: ignore
+        self._bounding_rect = None
+
+        # default state for graph
+        self.__past_clock_times = deque([0], maxlen=100)
+
+    def _draw_figure_to_surface(self) -> Optional[Surface]:
+        """
+        Handles creating the matplotlib figure and drawing the figure to
+        a pygame surface.
+        """
+        figure = Figure(
+            figsize=(self.graph_width / 100, self.graph_height / 100), dpi=100
+        )
+        figure = self.create_figure(figure)
+
+        if figure is not None:
+            canvas = FigureCanvasAgg(figure)
+            canvas.draw()
+            graph_surface = pygame.image.frombuffer(
+                canvas.buffer_rgba(),
+                canvas.get_width_height(),
+                "RGBA",
+            ).copy()
+            return graph_surface
+        return None
+
+    def create_figure(self, figure: Figure) -> Optional[Figure]:
+        """
+        This function is called once per each draw cycle. If the function
+        returns a matplotlib figure, the panel will render that graph
+        into the panel following the panels height and width.
+
+        The default implementation shows a sine wave based on the past
+        simulation clock times.
+        """
+        figure.patch.set_alpha(0.0)
+        axes = figure.add_subplot(111)
+        axes.patch.set_alpha(0.0)
+
+        # draw sine wave
+        axes.plot(self.__past_clock_times, [sin(x) for x in self.__past_clock_times])
+
+        # you might need need to pad in the graph otherwise it will be cut off
+        # usually its the labels for axes that get cut off the most
+        figure.subplots_adjust(left=0.15, right=0.85, bottom=0.2, top=0.8)
+
+        return figure
+
+    def listen_to(self) -> List[EventType]:
+        return [
+            EventType.VISUALIZATION_CREATED,
+            EventType.RENDER_UI,
+            EventType.POST_EVENT_LOOP,
+        ]
+
+    def handle_event(self, event: Event) -> bool:
+        if check_event(event, EventType.VISUALIZATION_CREATED):
+            self._fonter = pygame.font.SysFont("Calibri", self._fontsize)
+            self._title_fonter = pygame.font.SysFont("Calibri", self._title_fontsize)
+        elif check_event(event, EventType.RENDER_UI):
+            self.render(event.window)
+        elif check_event(event, EventType.POST_EVENT_LOOP):
+            if event.sim.clock > self.__past_clock_times[-1]:
+                self.__past_clock_times.append(event.sim.clock)
+        return True
+
+    def render(self, window: Surface):
+        """
+        Renders the current transitions fired per seconds.
+        """
+        width_offset = window.get_width() - self.graph_width - self.right_offset
+        height_offset = self.top_offset
+        self._bounding_rect = pygame.Rect(
+            width_offset, height_offset, self.graph_width, self.graph_height + 50
+        )
+
+        # draw background
+        pygame.draw.rect(
+            window,
+            TUE_LIGHTBLUE,
+            self._bounding_rect,
+            border_radius=5,
+        )
+        pygame.draw.rect(
+            window,
+            TUE_BLUE,
+            self._bounding_rect,
+            LINE_WIDTH,
+            border_radius=5,
+        )
+
+        # draw text for the panel
+        last_x, last_y = prevent_overflow_while_rendering(
+            window,
+            lambda t: self._title_fonter.render(t, True, TUE_BLUE),
+            self._bounding_rect.width - 10,
+            self.title,
+            (self._bounding_rect.x + 5, self._bounding_rect.y + 5),
+            2.5,
+        )
+        _, last_y = prevent_overflow_while_rendering(
+            window,
+            lambda t: self._fonter.render(t, True, TUE_BLUE),
+            self._bounding_rect.width - 10,
+            self.subtext,
+            (self._bounding_rect.x + 5, last_y + 5),
+            2.5,
+        )
+
+        # collect the figure and draw it to the panel
+        graph_surface = self._draw_figure_to_surface()
+        if graph_surface is not None:
+            window.blit(
+                graph_surface,
+                (self._bounding_rect.x + 10, last_y + 5),
+            )

--- a/tests/test_bps_priorities.py
+++ b/tests/test_bps_priorities.py
@@ -285,7 +285,7 @@ class TestWeightedFirstClassPriority(unittest.TestCase):
         self.problem = create_dummy_bpmn(structured=True)
         self.ideal_priority = WeightedFirstClassPriority(
             class_attr="type",
-            weights={"gold": 5, "silver": 2.5, "bronze": 0.5},
+            weights={"gold": 12.5, "silver": 2.5, "bronze": 0.5},
         )
         return super().setUp()
 


### PR DESCRIPTION
This patch adds a panel mod that allows for users to include a graph that is updated on every draw cycle of the mod. The patch introduces `GraphingPanel` into `visualisation.model_panel_mods`, which provides a general interface for including a graphing panel. By default the mod shows a sine wave to demonstrate how to make new graphing panels.

User designing new panels will need to subclass from `GraphingPanel` and overide the `create_figure` function on the class. The base class has a bunch of useful default parameters to make customising the panel for the user.

I updated two examples, `sandbox\priorities_for_bps.py` and `examples\presentation\presentation_4b.py`, to include custom graphing panels as examples of how to approach making new graphing panels. See below for examples.

<img width="1678" height="950" alt="priorities_demo" src="https://github.com/user-attachments/assets/31aa1d1c-e755-450b-a165-c53b2a0e54b7" />
<img width="1667" height="957" alt="presentation_4b" src="https://github.com/user-attachments/assets/ed42d7e1-f48f-4f06-9f27-4826461167bd" />

